### PR TITLE
Task 3: Undo add and remove from reading list 

### DIFF
--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -1,6 +1,9 @@
 describe('When: I use the reading list feature', () => {
+  let readingItemsCount = 0;
+
   beforeEach(() => {
     cy.startAt('/');
+    readingItemsCount = cy.$$('[data-testing="reading-list-item"]').length;
   });
 
   it('Then: I should see my reading list', () => {
@@ -9,6 +12,64 @@ describe('When: I use the reading list feature', () => {
     cy.get('[data-testing="reading-list-container"]').should(
       'contain.text',
       'My Reading List'
+    );
+  });
+
+  it('Then: I should be able to add book and undo added book', () => {
+    cy.get('input[type="search"]').type('angular');
+
+    cy.get('form').submit();
+
+    cy.get('[data-testing="add-book-to-list"]:enabled').first().click();
+
+    cy.get('[data-testing="reading-list-item"]').should(
+      'have.length',
+      readingItemsCount + 1
+    );
+
+    cy.get('.mat-simple-snackbar span').should(
+      'contain',
+      'added to reading list'
+    );
+
+    //undo add to reading list
+    cy.get('.mat-simple-snackbar-action button').click();
+
+    cy.get('[data-testing="reading-list-item"]').should(
+      'have.length',
+      readingItemsCount
+    );
+  });
+
+  it('Then: I should be able to remove book and undo removed book', () => {
+    cy.get('input[type="search"]').type('angular');
+
+    cy.get('form').submit();
+
+    cy.get('[data-testing="add-book-to-list"]:enabled').first().click();
+
+    cy.get('[data-testing="reading-list-item"]').should(
+      'have.length',
+      readingItemsCount + 1
+    );
+
+    cy.get('[data-testing="toggle-reading-list"]').click();
+
+    cy.get('[data-testing="remove-book-from-list"]:enabled').first().click();
+
+    cy.get('[data-testing="reading-list-close-cta"]').click();
+
+    cy.get('[data-testing="reading-list-item"]').should(
+      'have.length',
+      readingItemsCount
+    );
+
+    //undo remove from reading list
+    cy.get('.mat-simple-snackbar-action button').click();
+
+    cy.get('[data-testing="reading-list-item"]').should(
+      'have.length',
+      readingItemsCount + 1
     );
   });
 });

--- a/apps/okreads/browser/src/app/app.component.html
+++ b/apps/okreads/browser/src/app/app.component.html
@@ -24,7 +24,7 @@
     <div class="reading-list-container" data-testing="reading-list-container">
       <h2>
         My Reading List
-        <button mat-icon-button aria-label="Close reading list" (click)="drawer.close()">
+        <button mat-icon-button aria-label="Close reading list" (click)="drawer.close()" data-testing="reading-list-close-cta">
           <mat-icon>close</mat-icon>
         </button>
       </h2>

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
@@ -4,18 +4,27 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 
-import { SharedTestingModule } from '@tmo/shared/testing';
+import { SharedTestingModule, createBook, createReadingListItem } from '@tmo/shared/testing';
 import { ReadingListEffects } from './reading-list.effects';
 import * as ReadingListActions from './reading-list.actions';
+import { Book, ReadingListItem } from '@tmo/shared/models';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
-describe('ToReadEffects', () => {
+describe('ReadingListEffect', () => {
   let actions: ReplaySubject<any>;
   let effects: ReadingListEffects;
   let httpMock: HttpTestingController;
+  let item: ReadingListItem;
+  let book: Book;
+
+  beforeAll(() => {
+    item = createReadingListItem('A');
+    book = createBook('A');
+  });
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SharedTestingModule],
+      imports: [SharedTestingModule,MatSnackBarModule],
       providers: [
         ReadingListEffects,
         provideMockActions(() => actions),
@@ -25,6 +34,7 @@ describe('ToReadEffects', () => {
 
     effects = TestBed.inject(ReadingListEffects);
     httpMock = TestBed.inject(HttpTestingController);
+    actions = new ReplaySubject();
   });
 
   describe('loadReadingList$', () => {
@@ -40,6 +50,126 @@ describe('ToReadEffects', () => {
       });
 
       httpMock.expectOne('/api/reading-list').flush([]);
+    });
+  });
+
+  describe('addBook$', () => {
+    it('should add a book to the reading list successfully', (done) => {
+      actions.next(ReadingListActions.addToReadingList({ book }));
+
+      effects.addBook$.subscribe((action) => {
+        expect(action).toEqual(
+          ReadingListActions.confirmedAddToReadingList({ book })
+        );
+        done();
+      });
+
+      httpMock.expectOne('/api/reading-list').flush({});
+    });
+
+    it('should undo the added book when API returns error', (done) => {
+      actions.next(ReadingListActions.addToReadingList({ book }));
+
+      effects.addBook$.subscribe((action) => {
+        expect(action).toEqual(
+          ReadingListActions.failedAddToReadingList({ book })
+        );
+        done();
+      });
+
+      httpMock
+        .expectOne('/api/reading-list')
+        .flush({}, { status: 500, statusText: 'server error' });
+    });
+  });
+
+  describe('confirmAddBook$', () => {
+    beforeEach(() => {
+      jest.spyOn(effects, 'openSnackBar');
+    });
+
+    it('should open snackbar when a book is added successfully to reading list', () => {
+      actions.next(ReadingListActions.confirmedAddToReadingList({ book }));
+
+      effects.undoAddtoReadingList$.subscribe(() => {
+        expect(effects.openSnackBar).toHaveBeenCalledWith(
+          'Added "' + `${book.title}` + '" to the reading list',
+          'Undo',
+          ReadingListActions.removeFromReadingList({
+            item,
+          })
+        );
+      });
+    });
+
+    it('should not open snackbar while performing undo action after removing a book', () => {
+      actions.next(ReadingListActions.confirmedAddToReadingList({ book }));
+
+      effects.undoAddtoReadingList$.subscribe(() => {
+        expect(effects.openSnackBar).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('removeBook$', () => {
+    it('should remove book successfully from reading list', (done) => {
+      actions.next(ReadingListActions.removeFromReadingList({ item }));
+
+      effects.removeBook$.subscribe((action) => {
+        expect(action).toEqual(
+          ReadingListActions.confirmedRemoveFromReadingList({
+            item,
+          })
+        );
+        done();
+      });
+
+      httpMock.expectOne(`/api/reading-list/${item.bookId}`).flush({});
+    });
+
+    it('should undo removed book when API returns error', (done) => {
+      actions.next(ReadingListActions.removeFromReadingList({ item }));
+
+      effects.removeBook$.subscribe((action) => {
+        expect(action).toEqual(
+          ReadingListActions.failedRemoveFromReadingList({
+            item,
+          })
+        );
+        done();
+      });
+
+      httpMock
+        .expectOne(`/api/reading-list/${item.bookId}`)
+        .flush({}, { status: 500, statusText: 'server error' });
+    });
+  });
+
+  describe('confirmRemoveBook$', () => {
+    beforeEach(() => {
+      jest.spyOn(effects, 'openSnackBar');
+    });
+
+    it('should open snackbar when book is removed successfully from reading list', () => {
+      actions.next(ReadingListActions.confirmedRemoveFromReadingList({ item }));
+
+      effects.undoRemoveFromReadingList$.subscribe(() => {
+        expect(effects.openSnackBar).toHaveBeenCalledWith(
+          'Removed "' + `${item.title}` + '" from the reading list',
+          'Undo',
+          ReadingListActions.addToReadingList({
+            book,
+          })
+        );
+      });
+    });
+
+    it('should not open snackbar while performing undo action after adding a book', () => {
+      actions.next(ReadingListActions.confirmedRemoveFromReadingList({ item }));
+
+      effects.undoRemoveFromReadingList$.subscribe(() => {
+        expect(effects.openSnackBar).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.ts
@@ -2,9 +2,12 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Actions, createEffect, ofType, OnInitEffects } from '@ngrx/effects';
 import { of } from 'rxjs';
-import { catchError, concatMap, exhaustMap, map } from 'rxjs/operators';
-import { ReadingListItem } from '@tmo/shared/models';
+import { catchError, concatMap, exhaustMap, filter, map } from 'rxjs/operators';
+import { Book, ReadingListItem } from '@tmo/shared/models';
 import * as ReadingListActions from './reading-list.actions';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Store } from '@ngrx/store';
+import { ReadingListConstants } from '../reading-list.contants';
 
 @Injectable()
 export class ReadingListEffects implements OnInitEffects {
@@ -54,9 +57,70 @@ export class ReadingListEffects implements OnInitEffects {
     )
   );
 
+  undoAddtoReadingList$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(ReadingListActions.confirmedAddToReadingList),
+        filter(({ book }) => book.isOpenSnackBar),
+        map(({ book }) =>
+          this.openSnackBar(
+            { ...book, bookId: book.id, isOpenSnackBar: false },
+            `${book.title}: ${ReadingListConstants.ACTION_ADD_MSG}`,
+            true
+          )
+        )
+      ),
+    { dispatch: false }
+  );
+  undoRemoveFromReadingList$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(ReadingListActions.confirmedRemoveFromReadingList),
+        filter(({ item }) => item.isOpenSnackBar),
+        map(({ item }) =>
+          this.openSnackBar(
+            { ...item, id: item.bookId, isOpenSnackBar: false },
+            `${item.title}: ${ReadingListConstants.ACTION_REMOVE_MSG}`,
+            false
+          )
+        )
+      ),
+    { dispatch: false }
+  );
+
+  openSnackBar(
+    item: ReadingListItem | Book,
+    message: string,
+    isAdded: boolean
+  ): void {
+    this.snackBar
+      .open(message, ReadingListConstants.UNDO, {
+        duration: ReadingListConstants.DURATION,
+      })
+      .onAction()
+      .subscribe(() =>
+        isAdded
+          ? this.store.dispatch(
+              ReadingListActions.removeFromReadingList({
+                item: item as ReadingListItem,
+              })
+            )
+          : this.store.dispatch(
+              ReadingListActions.addToReadingList({
+                book: item as Book,
+              })
+            )
+      );
+  }
+
   ngrxOnInitEffects() {
     return ReadingListActions.init();
   }
 
-  constructor(private actions$: Actions, private http: HttpClient) {}
+  constructor(
+    private actions$: Actions,
+    private http: HttpClient,
+    private snackBar: MatSnackBar,
+    private store: Store
+  ) {}
 }

--- a/libs/books/data-access/src/lib/reading-list.contants.ts
+++ b/libs/books/data-access/src/lib/reading-list.contants.ts
@@ -1,0 +1,6 @@
+export const ReadingListConstants = {
+  UNDO: 'undo',
+  ACTION_REMOVE_MSG: 'removed from reading list',
+  ACTION_ADD_MSG: 'added to reading list',
+  DURATION: 3000,
+};

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -33,6 +33,7 @@
           <div>
             <button
               mat-flat-button
+              data-testing="add-book-to-list"
               color="primary"
               (click)="addBookToReadingList(book)"
               [disabled]="book.isAdded"

--- a/libs/books/feature/src/lib/book-search/book-search.component.ts
+++ b/libs/books/feature/src/lib/book-search/book-search.component.ts
@@ -31,7 +31,9 @@ export class BookSearchComponent {
   }
 
   addBookToReadingList(book: Book) {
-    this.store.dispatch(addToReadingList({ book }));
+    this.store.dispatch(
+      addToReadingList({ book: { ...book, isOpenSnackBar: true } })
+    );
   }
 
   searchExample() {

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="(readingList$ | async).length > 0; else empty">
-  <div class="reading-list-item" *ngFor="let book of readingList$ | async">
+  <div class="reading-list-item" data-testing="reading-list-item" *ngFor="let book of readingList$ | async">
     <div>
       <img class="reading-list-item--cover" [src]="book.coverUrl" />
     </div>
@@ -12,6 +12,7 @@
     <div>
       <button
         mat-icon-button
+        data-testing="remove-book-from-list"
         color="warn"
         [attr.aria-label]="'Remove ' + book.title + ' from reading list'"
         (click)="removeFromReadingList(book)"

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.ts
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
+import { ReadingListItem } from '@tmo/shared/models';
 
 @Component({
   selector: 'tmo-reading-list',
@@ -12,7 +13,7 @@ export class ReadingListComponent {
 
   constructor(private readonly store: Store) {}
 
-  removeFromReadingList(item) {
-    this.store.dispatch(removeFromReadingList({ item }));
+  removeFromReadingList(item: ReadingListItem) {
+    this.store.dispatch(removeFromReadingList({ item : { ...item, isOpenSnackBar: true }}));
   }
 }

--- a/libs/shared/models/src/models.ts
+++ b/libs/shared/models/src/models.ts
@@ -6,6 +6,7 @@ export interface Book {
   publisher?: string;
   publishedDate?: string;
   coverUrl?: string;
+  isOpenSnackBar: boolean;
 }
 
 export interface ReadingListItem extends Omit<Book, 'id'> {


### PR DESCRIPTION
Undo Add and Remove from reading list

- Implemented undo functionality on addition/removal of book.
- On successful addition to reading list or on successful removal from reading list, snack bar will open with undo button.
- Added test cases to ensure the functionality.

Screen shots

- Lint
<img width="657" alt="Screenshot 2023-11-28 at 11 40 09 PM" src="https://github.com/sherinRoy/DW3-Puzzle/assets/148328772/8c7470af-70d7-4235-9806-63d08efa4051">

- Unit test
<img width="919" alt="Screenshot 2023-11-28 at 11 40 56 PM" src="https://github.com/sherinRoy/DW3-Puzzle/assets/148328772/ebe1b369-aa47-4bf9-9ef1-40f30c050145">

- e2e test
<img width="1040" alt="Screenshot 2023-11-28 at 11 52 20 PM" src="https://github.com/sherinRoy/DW3-Puzzle/assets/148328772/ec543777-2599-4a31-be01-b5591ce9ea69">

- Task 3 screenshot
<img width="1503" alt="Screenshot 2023-11-28 at 11 39 40 PM" src="https://github.com/sherinRoy/DW3-Puzzle/assets/148328772/11352787-996c-41a1-9072-27e677486bc7">


https://github.com/sherinRoy/DW3-Puzzle/assets/148328772/e8e75583-3c92-426a-bd21-a5587710ffbf


https://github.com/sherinRoy/DW3-Puzzle/assets/148328772/92cce8ab-223f-4e0d-96a0-03c6fa4a54f1

